### PR TITLE
New listings require datetime available until. Fixed tests

### DIFF
--- a/client/cypress/integration/addListing.spec.js
+++ b/client/cypress/integration/addListing.spec.js
@@ -4,31 +4,23 @@ describe('Add Listing', () => {
     cy.visit('/listings/new');
     cy.contains('Number of Meals');
     cy.contains('Description');
+    cy.contains('Available Until');
     cy.contains('Create Listing');
   });
 
   it('checks click', () => {
-    cy.visit('/listings/new');
-    cy.get('#meals').type('10');
-    cy.get('#desc').type('Hello, World');
-    cy.get('.btn').click();
+    cy.addListing('10', 'Hello, World', '2025-01-01T23:55');
     cy.focused().should('have.attr', 'type', 'submit');
   });
 
   it('checks submitted data appears in feed', () => {
-    cy.visit('/listings/new');
-    cy.get('#meals').type('10');
-    cy.get('#desc').type('Hello, World');
-    cy.get('.btn').click();
+    cy.addListing('10', 'Hello, World', '2025-01-01T23:55');
     cy.get('#feed-link').click();
     cy.contains('Hello, World');
   });
 
   it('prevents invalid submission', () => {
-    cy.visit('/listings/new');
-   cy.get('#meals').type('0');
-    cy.get('#desc').type('Hello, World');
-    cy.get('.btn').click();
+    cy.addListing('0', 'Hello, World', '2025-01-01T23:55');
     cy.get('.listing-form').within(() => {
       cy.get('#meals')
         .invoke('prop', 'validationMessage')
@@ -37,29 +29,20 @@ describe('Add Listing', () => {
   });
 
   it('displays notice confirming new listing has been added', () => {
-    cy.visit('/listings/new');
-    cy.get('#meals').type('10');
-    cy.get('#desc').type('Hello, World');
-    cy.get('.btn').click();
+    cy.addListing('10', 'Hello, World', '2025-01-01T23:55');
     cy.get('#submission-notice').contains(
       'Your food listing has been successfully added.',
     );
   });
 
   it('clears success notice after 3 seconds', () => {
-    cy.visit('/listings/new');
-    cy.get('#meals').type('10');
-    cy.get('#desc').type('Hello, World');
-    cy.get('.btn').click();
+    cy.addListing('10', 'Hello, World', '2025-01-01T23:55');
     cy.wait(2001);
     cy.get('#submission-notice').should('not.exist');
   });
 
   it('clears the form after success', () => {
-    cy.visit('/listings/new');
-    cy.get('#meals').type('10');
-    cy.get('#desc').type('Hello, World');
-    cy.get('.btn').click();
+    cy.addListing('10', 'Hello, World', '2025-01-01T23:55');
     cy.get('#meals').contains('10').should('not.exist');
     cy.get('#desc').contains('Hello, World').should('not.exist');
   });

--- a/client/cypress/integration/claimListing.spec.js
+++ b/client/cypress/integration/claimListing.spec.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 
 describe('Claiming a listing', () => {
   it('can claim a listing', () => {
-    cy.addListing(10, 'Test listing to be claimed');
+    cy.addListing('10', 'Test listing to be claimed', '2025-01-01T23:55');
 
     cy.visit('/feed');
     cy.get('.btn').first().click();
@@ -16,7 +16,7 @@ describe('Claiming a listing', () => {
   });
 
   it('allows the user to confirm', () => {
-    cy.addListing(10, 'Test listing to be claimed');
+    cy.addListing('10', 'Test listing to be claimed', '2025-01-01T23:55');
 
     cy.visit('/feed');
     cy.get('.btn').first().click();
@@ -24,7 +24,7 @@ describe('Claiming a listing', () => {
   });
 
   it('allows the user to go back', () => {
-    cy.addListing(10, 'Test listing to be claimed');
+    cy.addListing('10', 'Test listing to be claimed', '2025-01-01T23:55');
 
     cy.visit('/feed');
     cy.get('.btn').first().click();
@@ -32,7 +32,7 @@ describe('Claiming a listing', () => {
   });
 
   it('go back returns to feed', () => {
-    cy.addListing(10, 'Test listing to be claimed');
+    cy.addListing('10', 'Test listing to be claimed', '2025-01-01T23:55');
 
     cy.visit('/feed');
     cy.get('.btn').first().click();

--- a/client/cypress/integration/loginForm.spec.js
+++ b/client/cypress/integration/loginForm.spec.js
@@ -1,10 +1,23 @@
 /* eslint-disable jest/valid-expect */
 /* eslint-disable no-undef */
-describe('Signup', () => {
+describe('Login', () => {
   it('should redirect to feed after successful login', () => {
+    cy.signup(
+      'Charity Login',
+      'char1@gmail.com',
+      'test',
+      'test',
+      '1 Road St',
+      'London',
+      'SW12 9RG',
+      '07777123456',
+      'Charity',
+      '012345',
+      'www.charity.com',
+    );
     cy.visit('/login');
-    cy.get('#username').type('Charity Supreme');
-    cy.get('#password').type('Charity123!');
+    cy.get('#username').type('Charity Login');
+    cy.get('#password').type('test');
     cy.get('#loginSubmit').click();
     cy.location('pathname').should('eq', '/feed');
   });

--- a/client/cypress/support/commands.js
+++ b/client/cypress/support/commands.js
@@ -12,9 +12,43 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
-Cypress.Commands.add('addListing', (meals, desc) => {
-  cy.visit('http://localhost:3000/listings/new');
+Cypress.Commands.add('addListing', (meals, desc, availableTo) => {
+  cy.visit('/listings/new');
   cy.get('#meals').type(meals);
   cy.get('#desc').type(desc);
+  cy.get('#timeAvailableUntil').type(availableTo);
   cy.get('.btn').click();
 });
+
+Cypress.Commands.add(
+  'signup',
+  (
+    username,
+    email,
+    password,
+    passwordConfirm,
+    add1,
+    city,
+    postcode,
+    tel,
+    desc,
+    charityNo,
+    website,
+  ) => {
+    cy.visit('/signup');
+    cy.get('#charity-btn').click();
+    cy.get('#username').type(username);
+    cy.get('#emailAddress').type(email);
+    cy.get('#password').type(password);
+    cy.get('#passwordConfirmation').type(passwordConfirm);
+    cy.get('#addressLine1').type(add1);
+    cy.get('#addressLine2');
+    cy.get('#city').type(city);
+    cy.get('#postCode').type(postcode);
+    cy.get('#contactNumber').type(tel);
+    cy.get('#description').type(desc);
+    cy.get('#charityNumber').type(charityNo);
+    cy.get('#websiteLink').type(website);
+    cy.get('#charitySubmit').click();
+  },
+);

--- a/client/cypress/support/commands.js
+++ b/client/cypress/support/commands.js
@@ -18,6 +18,7 @@ Cypress.Commands.add('addListing', (meals, desc, availableTo) => {
   cy.get('#desc').type(desc);
   cy.get('#timeAvailableUntil').type(availableTo);
   cy.get('#create-listing-btn').click();
+ });
 
 Cypress.Commands.add('charityLogin', () => {
   cy.visit('/login');

--- a/client/cypress/support/commands.js
+++ b/client/cypress/support/commands.js
@@ -18,7 +18,7 @@ Cypress.Commands.add('addListing', (meals, desc, availableTo) => {
   cy.get('#desc').type(desc);
   cy.get('#timeAvailableUntil').type(availableTo);
   cy.get('#create-listing-btn').click();
- });
+});
 
 Cypress.Commands.add('charityLogin', () => {
   cy.visit('/login');

--- a/client/src/components/ListingForm.js
+++ b/client/src/components/ListingForm.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import React, { Component } from 'react';
 import axios from 'axios';
 
@@ -9,11 +10,12 @@ export default class ListingForm extends Component {
 
     this.updateNumberOfMeals = this.updateNumberOfMeals.bind(this);
     this.updateDescription = this.updateDescription.bind(this);
+    this.updateDate = this.updateDateTime.bind(this);
 
     this.state = {
       numberOfMeals: '',
       description: '',
-      timeAvailableUntil: null,
+      timeAvailableUntil: '',
       listedBy: '',
       showNotice: false,
     };
@@ -23,6 +25,7 @@ export default class ListingForm extends Component {
     this.setState({
       numberOfMeals: '',
       description: '',
+      timeAvailableUntil: '',
     });
   }
 
@@ -49,12 +52,18 @@ export default class ListingForm extends Component {
     });
   }
 
+  updateDateTime(e) {
+    this.setState({
+      timeAvailableUntil: e.target.value,
+    });
+  }
+
   handleSubmit(e) {
     e.preventDefault();
     const listing = {
       numberOfMeals: this.state.numberOfMeals,
       description: this.state.description,
-      timeAvailableUntil: new Date(),
+      timeAvailableUntil: this.state.timeAvailableUntil,
       listedBy: 1, // just a default
     };
 
@@ -84,6 +93,7 @@ export default class ListingForm extends Component {
               onChange={this.updateNumberOfMeals}
             />
           </div>
+
           <div className="form-group">
             <label className="mt-2 mb-2" htmlFor="desc">
               Description
@@ -102,6 +112,20 @@ export default class ListingForm extends Component {
               requirements.
             </small>
           </div>
+
+          <div className="form-group">
+            <label className="mt-2 mb-2" htmlFor="timeAvailableUntil">
+              Available Until:
+            </label>
+            <input
+              className="form-control"
+              type="datetime-local"
+              name="timeAvailableUntil"
+              id="timeAvailableUntil"
+              onChange={this.updateDateTime.bind(this)}
+            />
+          </div>
+
           <div className="form-submit">
             <button className="btn btn-outline-success mt-3" type="submit">
               Create Listing


### PR DESCRIPTION
-Added some customer cypress commands to improve testing. 
-Added a signup before the login tests would pass for me. Alternatively we get the signup tests to run before the login ones. 
-User must enter date/time with their listing. This shows on the listing page. Currently not testing that the date/time shows on the listings page (it does but I want to improve the formatting e.g. will have future testing for contains something nicer, maybe 'Mon 12th Nov 2021 11:55PM' 