### PR TITLE
Don't show expired listings in feed

### DIFF
--- a/client/cypress.json
+++ b/client/cypress.json
@@ -5,7 +5,7 @@
     "loginForm.spec.js",
     "navbar.spec.js",
     "addListing.spec.js",
-    "viewListing.spec.js",
+    "viewListings.spec.js",
     "claimListing.spec.js"
   ]
 }

--- a/client/cypress/integration/viewListings.spec.js
+++ b/client/cypress/integration/viewListings.spec.js
@@ -35,7 +35,7 @@ describe('View Listings', () => {
     cy.get('This listing should not appear').should('not.exist');
   });
 
-  it('only shows listings available in the future', () => {
+  it('should not show listings available in the past', () => {
     let now = new Date(new Date().toString().split('GMT')[0] + ' UTC')
       .toISOString()
       .split('.')[0];
@@ -49,5 +49,13 @@ describe('View Listings', () => {
     cy.wait(1000);
     cy.visit('/feed');
     cy.get('This listing should not appear').should('not.exist');
+  });
+
+  it('should show listings available in the future', () => {
+    cy.switchToRestaurant();
+    cy.addListing('10', 'This listing should appear', `2225-01-01T23:55`);
+    cy.wait(1000);
+    cy.switchToCharity();
+    cy.contains('This listing should appear');
   });
 });

--- a/client/cypress/integration/viewListings.spec.js
+++ b/client/cypress/integration/viewListings.spec.js
@@ -1,16 +1,11 @@
+/* eslint-disable jest/valid-expect-in-promise */
 /* eslint-disable no-undef */
 import axios from 'axios';
 
-describe('View Listing', () => {
+describe('View Listings', () => {
   beforeEach(() => {
     cy.charityLogin();
   });
-
-  // it('renders listings from dummy data', () => {
-  //   // still to do - test db with seed data for improved testing
-  //   cy.visit('/feed');
-  //   cy.contains('test');
-  // });
 
   it('contains the listing headers', () => {
     cy.contains('Listed by');
@@ -37,6 +32,22 @@ describe('View Listing', () => {
         console.log(error);
       });
     console.log(process.env.NODE_ENV);
+    cy.get('This listing should not appear').should('not.exist');
+  });
+
+  it('only shows listings available in the future', () => {
+    let now = new Date(new Date().toString().split('GMT')[0] + ' UTC')
+      .toISOString()
+      .split('.')[0];
+    cy.switchToRestaurant();
+    cy.addListing(
+      '10',
+      'This listing should not appear',
+      `${now.substring(0, now.length - 3)}`,
+    );
+    cy.switchToCharity();
+    cy.wait(1000);
+    cy.visit('/feed');
     cy.get('This listing should not appear').should('not.exist');
   });
 });

--- a/client/cypress/integration/viewListings.spec.js
+++ b/client/cypress/integration/viewListings.spec.js
@@ -47,7 +47,7 @@ describe('View Listings', () => {
     );
     cy.switchToCharity();
     cy.wait(1000);
-    cy.visit('/feed');
+    cy.get('#feed-link').click();
     cy.get('This listing should not appear').should('not.exist');
   });
 

--- a/client/src/components/ListingFeed.component.js
+++ b/client/src/components/ListingFeed.component.js
@@ -15,7 +15,10 @@ export default class ListingFeed extends Component {
 
   availableListings(data) {
     return data.filter((currentListing) => {
-      return !currentListing.claimedBy;
+      return (
+        !currentListing.claimedBy &&
+        new Date(currentListing.timeAvailableUntil) > new Date()
+      );
     });
   }
 


### PR DESCRIPTION
-ViewListings.spec.js was not being picked up in cypress tests, updated the cypress json and describe line in the ViewListings .spec.js so these are all the same. 
-Feature test for expired listing not show and listing in the future shown.
-Filtering added on front end when loading listings page to exclude those with date earlier than now.